### PR TITLE
feat: add ESP-IDF support

### DIFF
--- a/components/nspanel_lovelace/__init__.py
+++ b/components/nspanel_lovelace/__init__.py
@@ -1,12 +1,12 @@
 from esphome import automation
 import esphome.config_validation as cv
 import esphome.codegen as cg
-
 from esphome.components import mqtt, uart
 from esphome.const import (
     CONF_ID,
     CONF_TRIGGER_ID,
 )
+from esphome.core import CORE
 
 AUTO_LOAD = ["text_sensor"]
 CODEOWNERS = ["@sairon"]
@@ -60,7 +60,6 @@ CONFIG_SCHEMA = cv.All(
     )
         .extend(uart.UART_DEVICE_SCHEMA)
         .extend(cv.COMPONENT_SCHEMA),
-    cv.only_with_arduino,
     validate_config
         )
 
@@ -82,6 +81,8 @@ async def to_code(config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
-    cg.add_library("WiFiClientSecure", None)
-    cg.add_library("HTTPClient", None)
+    if CORE.is_esp32 and CORE.using_arduino:
+        cg.add_library("WiFiClientSecure", None)
+        cg.add_library("HTTPClient", None)
+
     cg.add_define("USE_NSPANEL_LOVELACE")

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -219,7 +219,12 @@ void NSPanelLovelace::exit_reparse_mode() {
 
 void NSPanelLovelace::set_baud_rate_(int baud_rate) {
   // hopefully on NSPanel it should always be an ESP32ArduinoUARTComponent instance
+#ifdef USE_ARDUINO
   auto *uart = reinterpret_cast<uart::ESP32ArduinoUARTComponent *>(this->parent_);
+#endif
+#ifdef USE_ESP_IDF
+  auto *uart = reinterpret_cast<uart::IDFUARTComponent *>(this->parent_);
+#endif
   uart->set_baud_rate(baud_rate);
   uart->setup();
 }

--- a/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
@@ -14,6 +14,7 @@ static const char *const TAG = "nspanel_lovelace_upload";
 // Followed guide
 // https://unofficialnextion.com/t/nextion-upload-protocol-v1-2-the-fast-one/1044/2
 
+#ifdef USE_ARDUINO
 int NSPanelLovelace::upload_by_chunks_(HTTPClient *http, const std::string &url, int range_start) {
   int range_end;
 
@@ -49,7 +50,7 @@ int NSPanelLovelace::upload_by_chunks_(HTTPClient *http, const std::string &url,
     if (code == 200 || code == 206) {
       break;
     }
-    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s, retries(%d/5)", this->tft_url_.c_str(),
+    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s, retries(%d/5)", url.c_str(),
              HTTPClient::errorToString(code).c_str(), tries);
     http->end();
     delay(500);  // NOLINT
@@ -117,6 +118,207 @@ int NSPanelLovelace::upload_by_chunks_(HTTPClient *http, const std::string &url,
   }
   return range_end + 1;
 }
+#else
+int NSPanelLovelace::upload_by_chunks_(const std::string &url, int range_start) {
+  ESP_LOGVV(TAG, "url: %s", url.c_str());
+  uint range_size = this->tft_size_ - range_start;
+  ESP_LOGVV(TAG, "tft_size_: %i", this->tft_size_);
+  ESP_LOGV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  int range_end = (range_start == 0) ? std::min(this->tft_size_, 16383) : this->tft_size_;
+  if (range_size <= 0 or range_end <= range_start) {
+    ESP_LOGE(TAG, "Invalid range");
+    ESP_LOGD(TAG, "Range start: %i", range_start);
+    ESP_LOGD(TAG, "Range end: %i", range_end);
+    ESP_LOGD(TAG, "Range size: %i", range_size);
+    return -1;
+  }
+
+  esp_http_client_config_t config = {
+      .url = url.c_str(),
+      .cert_pem = nullptr,
+  };
+  esp_http_client_handle_t client = esp_http_client_init(&config);
+
+  char range_header[64];
+  sprintf(range_header, "bytes=%d-%d", range_start, range_end);
+  ESP_LOGV(TAG, "Requesting range: %s", range_header);
+  esp_http_client_set_header(client, "Range", range_header);
+  ESP_LOGVV(TAG, "Available heap: %u", esp_get_free_heap_size());
+
+  ESP_LOGV(TAG, "Opening http connetion");
+  esp_err_t err;
+  if ((err = esp_http_client_open(client, 0)) != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to open HTTP connection: %s", esp_err_to_name(err));
+    esp_http_client_cleanup(client);
+    return -1;
+  }
+
+  ESP_LOGV(TAG, "Fetch content length");
+  int content_length = esp_http_client_fetch_headers(client);
+  ESP_LOGV(TAG, "content_length = %d", content_length);
+  if (content_length <= 0) {
+    ESP_LOGE(TAG, "Failed to get content length: %d", content_length);
+    esp_http_client_cleanup(client);
+    return -1;
+  }
+
+  ESP_LOGV(TAG, "Allocate buffer");
+  uint8_t *buffer = new uint8_t[4096];
+  std::string recv_string;
+  if (buffer == nullptr) {
+    ESP_LOGE(TAG, "Failed to allocate memory for buffer");
+    ESP_LOGV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  } else {
+    ESP_LOGV(TAG, "Memory for buffer allocated successfully");
+
+    while (true) {
+      App.feed_wdt();
+      ESP_LOGVV(TAG, "Available heap: %u", esp_get_free_heap_size());
+      int read_len = esp_http_client_read(client, reinterpret_cast<char *>(buffer), 4096);
+      ESP_LOGVV(TAG, "Read %d bytes from HTTP client, writing to UART", read_len);
+      if (read_len > 0) {
+        this->write_array(buffer, read_len);
+        ESP_LOGVV(TAG, "Write to UART successful");
+        this->recv_ret_string_(recv_string, 5000, true);
+        this->content_length_ -= read_len;
+        ESP_LOGD(TAG, "Uploaded %0.2f %%, remaining %d bytes",
+                 100.0 * (this->tft_size_ - this->content_length_) / this->tft_size_, this->content_length_);
+        if (recv_string[0] != 0x05) {  // 0x05 == "ok"
+          ESP_LOGD(
+              TAG, "recv_string [%s]",
+              format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()), recv_string.size()).c_str());
+        }
+        // handle partial upload request
+        if (recv_string[0] == 0x08 && recv_string.size() == 5) {
+          uint32_t result = 0;
+          for (int j = 0; j < 4; ++j) {
+            result += static_cast<uint8_t>(recv_string[j + 1]) << (8 * j);
+          }
+          if (result > 0) {
+            ESP_LOGI(TAG, "Nextion reported new range %" PRIu32, result);
+            this->content_length_ = this->tft_size_ - result;
+            // Deallocate the buffer when done
+            delete[] buffer;
+            ESP_LOGVV(TAG, "Memory for buffer deallocated");
+            esp_http_client_cleanup(client);
+            esp_http_client_close(client);
+            return result;
+          }
+        }
+        recv_string.clear();
+      } else if (read_len == 0) {
+        ESP_LOGV(TAG, "End of HTTP response reached");
+        break;  // Exit the loop if there is no more data to read
+      } else {
+        ESP_LOGE(TAG, "Failed to read from HTTP client, error code: %d", read_len);
+        break;  // Exit the loop on error
+      }
+    }
+
+    // Deallocate the buffer when done
+    delete[] buffer;
+    ESP_LOGVV(TAG, "Memory for buffer deallocated");
+  }
+  esp_http_client_cleanup(client);
+  esp_http_client_close(client);
+  return range_end + 1;
+}
+#endif
+
+#ifdef USE_ARDUINO
+void NSPanelLovelace::init_upload(HTTPClient *http, const std::string &url) {
+  http->setTimeout(15000);  // Yes 15 seconds.... Helps 8266s along
+  http->setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+  bool begin_status = http->begin(url.c_str());
+
+  if (!begin_status) {
+    this->is_updating_ = false;
+    ESP_LOGD(TAG, "connection failed");
+    ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+    allocator.deallocate(this->transfer_buffer_, this->transfer_buffer_size_);
+    return;
+  } else {
+    ESP_LOGD(TAG, "Connected");
+  }
+
+  http->addHeader("Range", "bytes=0-255");
+  const char *header_names[] = {"Content-Range"};
+  http->collectHeaders(header_names, 1);
+  ESP_LOGD(TAG, "Requesting URL: %s", url.c_str());
+
+  http->setReuse(true);
+  // try up to 5 times. DNS sometimes needs a second try or so
+  int tries = 1;
+  int code = http->GET();
+  delay(100);  // NOLINT
+
+  while (code != 200 && code != 206 && tries <= 5) {
+    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s, retrying (%d/5)", url.c_str(),
+             HTTPClient::errorToString(code).c_str(), tries);
+
+    delay(250);  // NOLINT
+    code = http->GET();
+    ++tries;
+  }
+
+  if ((code != 200 && code != 206) || tries > 5) {
+    this->upload_end_();
+  }
+
+  String content_range_string = http->header("Content-Range");
+  content_range_string.remove(0, 12);
+  this->content_length_ = content_range_string.toInt();
+  this->tft_size_ = content_length_;
+  http->end();
+}
+#elif defined(USE_ESP_IDF)
+void NSPanelLovelace::init_upload(const std::string &url) {
+  // Define the configuration for the HTTP client
+  ESP_LOGV(TAG, "Establishing connection to HTTP server");
+  ESP_LOGVV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  esp_http_client_config_t config = {
+      .url = url.c_str(),
+      .cert_pem = nullptr,
+      .method = HTTP_METHOD_HEAD,
+      .timeout_ms = 15000,
+  };
+
+  // Initialize the HTTP client with the configuration
+  ESP_LOGV(TAG, "Initializing HTTP client");
+  ESP_LOGV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  esp_http_client_handle_t http = esp_http_client_init(&config);
+  if (!http) {
+    ESP_LOGE(TAG, "Failed to initialize HTTP client.");
+    return this->upload_end_();
+  }
+
+  // Perform the HTTP request
+  ESP_LOGV(TAG, "Check if the client could connect");
+  ESP_LOGV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  esp_err_t err = esp_http_client_perform(http);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "HTTP request failed: %s", esp_err_to_name(err));
+    esp_http_client_cleanup(http);
+    return this->upload_end_();
+  }
+
+  // Check the HTTP Status Code
+  int status_code = esp_http_client_get_status_code(http);
+  ESP_LOGV(TAG, "HTTP Status Code: %d", status_code);
+  size_t tft_file_size = esp_http_client_get_content_length(http);
+  ESP_LOGD(TAG, "TFT file size: %zu", tft_file_size);
+
+  if (tft_file_size < 4096) {
+    ESP_LOGE(TAG, "File size check failed. Size: %zu", tft_file_size);
+    esp_http_client_cleanup(http);
+    return this->upload_end_();
+  } else {
+    ESP_LOGV(TAG, "File size check passed. Proceeding...");
+  }
+  this->content_length_ = tft_file_size;
+  this->tft_size_ = tft_file_size;
+}
+#endif
 
 void NSPanelLovelace::upload_tft(const std::string &url) {
   if (this->is_updating_) {
@@ -135,50 +337,12 @@ void NSPanelLovelace::upload_tft(const std::string &url) {
 
   this->is_updating_ = true;
 
+#ifdef USE_ARDUINO
   HTTPClient http;
-  http.setTimeout(15000);  // Yes 15 seconds.... Helps 8266s along
-  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-  bool begin_status = http.begin(url.c_str());
-
-  if (!begin_status) {
-    this->is_updating_ = false;
-    ESP_LOGD(TAG, "connection failed");
-    ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
-    allocator.deallocate(this->transfer_buffer_, this->transfer_buffer_size_);
-    return;
-  } else {
-    ESP_LOGD(TAG, "Connected");
-  }
-
-  http.addHeader("Range", "bytes=0-255");
-  const char *header_names[] = {"Content-Range"};
-  http.collectHeaders(header_names, 1);
-  ESP_LOGD(TAG, "Requesting URL: %s", url.c_str());
-
-  http.setReuse(true);
-  // try up to 5 times. DNS sometimes needs a second try or so
-  int tries = 1;
-  int code = http.GET();
-  delay(100);  // NOLINT
-
-  while (code != 200 && code != 206 && tries <= 5) {
-    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s, retrying (%d/5)", url.c_str(),
-             HTTPClient::errorToString(code).c_str(), tries);
-
-    delay(250);  // NOLINT
-    code = http.GET();
-    ++tries;
-  }
-
-  if ((code != 200 && code != 206) || tries > 5) {
-    this->upload_end_();
-  }
-
-  String content_range_string = http.header("Content-Range");
-  content_range_string.remove(0, 12);
-  this->content_length_ = content_range_string.toInt();
-  this->tft_size_ = content_length_;
-  http.end();
+  this->init_upload(&http, url);
+#elif defined(USE_ESP_IDF)
+  this->init_upload(url);
+#endif
 
   if (this->content_length_ < 4096) {
     ESP_LOGE(TAG, "Failed to get file size");
@@ -226,10 +390,10 @@ void NSPanelLovelace::upload_tft(const std::string &url) {
 
   // Nextion wants 4096 bytes at a time. Make chunk_size a multiple of 4096
   uint32_t chunk_size = 8192;
-  if (ESP.getFreeHeap() > 40960) {  // 32K to keep on hand
-    chunk_size = ESP.getFreeHeap() - 32768;
+  if (esp_get_free_heap_size() > 40960) {  // 32K to keep on hand
+    chunk_size = esp_get_free_heap_size() - 32768;
     chunk_size = chunk_size > 65536 ? 65536 : chunk_size;
-  } else if (ESP.getFreeHeap() < 10240) {
+  } else if (esp_get_free_heap_size() < 10240) {
     chunk_size = 4096;
   }
 
@@ -237,7 +401,7 @@ void NSPanelLovelace::upload_tft(const std::string &url) {
   if (this->transfer_buffer_ == nullptr) {
     ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
     // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    ESP_LOGD(TAG, "Allocating buffer size %d, Heap size is %u", chunk_size, ESP.getFreeHeap());
+    ESP_LOGD(TAG, "Allocating buffer size %d, Heap size is %u", chunk_size, esp_get_free_heap_size());
     this->transfer_buffer_ = allocator.allocate(chunk_size);
     if (this->transfer_buffer_ == nullptr) {  // Try a smaller size
       ESP_LOGD(TAG, "Could not allocate buffer size: %d trying 4096 instead", chunk_size);
@@ -254,18 +418,22 @@ void NSPanelLovelace::upload_tft(const std::string &url) {
 
   // NOLINTNEXTLINE(readability-static-accessed-through-instance)
   ESP_LOGD(TAG, "Updating tft from \"%s\" with a file size of %d using %zu chunksize, Heap Size %d",
-           url.c_str(), this->content_length_, this->transfer_buffer_size_, ESP.getFreeHeap());
+           url.c_str(), this->content_length_, this->transfer_buffer_size_, esp_get_free_heap_size());
 
   int result = 0;
   while (this->content_length_ > 0) {
+#ifdef USE_ARDUINO
     result = this->upload_by_chunks_(&http, url, result);
+#elif defined(USE_ESP_IDF)
+    result = this->upload_by_chunks_(url, result);
+#endif
     if (result < 0) {
       ESP_LOGD(TAG, "Error updating Nextion!");
       this->upload_end_();
     }
     App.feed_wdt();
     // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    ESP_LOGD(TAG, "Heap Size %d, Bytes left %d", ESP.getFreeHeap(), this->content_length_);
+    ESP_LOGD(TAG, "Heap Size %d, Bytes left %d", esp_get_free_heap_size(), this->content_length_);
   }
   ESP_LOGD(TAG, "Successfully updated Nextion!");
 
@@ -277,7 +445,7 @@ void NSPanelLovelace::upload_end_() {
   this->soft_reset();
   delay(1500);  // NOLINT
   ESP_LOGD(TAG, "Restarting esphome");
-  ESP.restart();  // NOLINT(readability-static-accessed-through-instance)
+  esp_restart();
 }
 }  // namespace nspanel_lovelace
 }  // namespace esphome


### PR DESCRIPTION
Add support for `esp-idf` framework, partially based on ESPHome PR esphome/esphome#5667 by @edwardtfn (thank you, Edward!). The upstream code has been refactored to share more when Arduino or ESP-IDF is used and to use baud rate switching used in this "fork".

This is currently still WIP, I will do a bit more refactoring and testing, but initial tests are looking good and there are indeed some resource savings when compared to Arduino, as seen with my testing config:

Arduino:
```
RAM:   [=         ]  14.6% (used 47928 bytes from 327680 bytes)
Flash: [=======   ]  71.1% (used 1304205 bytes from 1835008 bytes)
```

ESP-IDF:
```
RAM:   [=         ]  10.7% (used 35048 bytes from 327680 bytes)
Flash: [======    ]  61.2% (used 1123305 bytes from 1835008 bytes)
```

Fixes #23.

For those who are eager to try (more testers are always welcome!), simply update `ref` in your config to `add-esp-idf-support`, and ideally also the `refresh` time:

```
external_components:
  - source:
      type: git
      url: https://github.com/sairon/esphome-nspanel-lovelace-ui
      ref: add-esp-idf-support
    refresh: 0s
    components: [ nspanel_lovelace ]
```

It is recommended to use serial for transition from Arduino to IDF, because IIRC the partition layout is a bit different, but I have tested the OTA works both ways without problems too.