### PR TITLE
Using Home Assistant API instead of MQTT

### DIFF
--- a/components/nspanel_lovelace/__init__.py
+++ b/components/nspanel_lovelace/__init__.py
@@ -10,22 +10,28 @@ from esphome.const import (
 
 AUTO_LOAD = ["text_sensor"]
 CODEOWNERS = ["@sairon"]
-DEPENDENCIES = ["uart", "wifi", "esp32"]
-# adding dependency - depends on at least on of "mqtt" or "api"
+DEPENDENCIES = [
+    "uart",
+    "wifi",
+    "esp32",
+]  # adding dependency later - depends on at least on of "mqtt" or "api"
+
 
 nspanel_lovelace_ns = cg.esphome_ns.namespace("nspanel_lovelace")
-NSPanelLovelace = nspanel_lovelace_ns.class_("NSPanelLovelace", cg.Component, uart.UARTDevice)
+NSPanelLovelace = nspanel_lovelace_ns.class_(
+    "NSPanelLovelace", cg.Component, uart.UARTDevice
+)
 
 
 NSPanelLovelaceMessageFromNextionTrigger = nspanel_lovelace_ns.class_(
     "NSPanelLovelaceMessageFromNextionTrigger",
-    automation.Trigger.template(cg.std_string)
+    automation.Trigger.template(cg.std_string),
 )
 NSPanelLovelaceMessageToNextionTrigger = nspanel_lovelace_ns.class_(
-    "NSPanelLovelaceMessageToNextionTrigger",
-    automation.Trigger.template(cg.std_string)
+    "NSPanelLovelaceMessageToNextionTrigger", automation.Trigger.template(cg.std_string)
 )
 
+CONF_USE_API = "use_api"
 CONF_API_PARENT_ID = "api_parent_id"
 CONF_MQTT_PARENT_ID = "mqtt_parent_id"
 CONF_MQTT_RECV_TOPIC = "mqtt_recv_topic"
@@ -36,39 +42,63 @@ CONF_BERRY_DRIVER_VERSION = "berry_driver_version"
 CONF_USE_MISSED_UPDATES_WORKAROUND = "use_missed_updates_workaround"
 CONF_UPDATE_BAUD_RATE = "update_baud_rate"
 
+
 def validate_config(config):
-    #TODO: add dependency - depends either "mqtt" or "api"
+    # add dependency - depends either "mqtt" or "api"
     if not CONF_API_PARENT_ID in config and not CONF_MQTT_PARENT_ID in config:
         raise cv.Invalid("Requires at least one of mqtt or api components.")
+
+    if config[CONF_USE_API]:
+        if not CONF_API_PARENT_ID in config:
+            raise cv.Invalid("This setting of 'use_api: True' requires api component.")
+    else:
+        if not CONF_MQTT_PARENT_ID in config:
+            raise cv.Invalid(
+                "This setting of 'use_api: False' requires mqtt component."
+            )
 
     if CONF_MQTT_PARENT_ID in config:
         if int(config[CONF_BERRY_DRIVER_VERSION]) > 0:
             if "CustomSend" not in config[CONF_MQTT_SEND_TOPIC]:
                 # backend uses topic_send.replace("CustomSend", ...) for GetDriverVersion and FlashNextion
-                raise cv.Invalid(f"{CONF_MQTT_SEND_TOPIC} must contain \"CustomSend\" for correct backend compatibility.\n"
-                                f"Either change it or set {CONF_BERRY_DRIVER_VERSION} to 0.")
-        
+                raise cv.Invalid(
+                    f'{CONF_MQTT_SEND_TOPIC} must contain "CustomSend" for correct backend compatibility.\n'
+                    f"Either change it or set {CONF_BERRY_DRIVER_VERSION} to 0."
+                )
+
     return config
+
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(NSPanelLovelace),
             cv.OnlyWith(CONF_API_PARENT_ID, "api"): cv.use_id(api.APIServer),
-            cv.OnlyWith(CONF_MQTT_PARENT_ID, "mqtt"): cv.use_id(mqtt.MQTTClientComponent),
-            cv.OnlyWith(CONF_MQTT_RECV_TOPIC, "mqtt", default="tele/nspanel/RESULT"): cv.All(cv.requires_component("mqtt"), cv.string),
-            cv.OnlyWith(CONF_MQTT_SEND_TOPIC, "mqtt", default="cmnd/nspanel/CustomSend"): cv.All(cv.requires_component("mqtt"), cv.string),
+            cv.OnlyWith(CONF_USE_API, "api", default=False): cv.boolean,
+            cv.OnlyWith(CONF_MQTT_PARENT_ID, "mqtt"): cv.use_id(
+                mqtt.MQTTClientComponent
+            ),
+            cv.OnlyWith(
+                CONF_MQTT_RECV_TOPIC, "mqtt", default="tele/nspanel/RESULT"
+            ): cv.All(cv.requires_component("mqtt"), cv.string),
+            cv.OnlyWith(
+                CONF_MQTT_SEND_TOPIC, "mqtt", default="cmnd/nspanel/CustomSend"
+            ): cv.All(cv.requires_component("mqtt"), cv.string),
             cv.Optional(CONF_MESSAGE_FROM_NEXTION): automation.validate_automation(
                 cv.Schema(
                     {
-                        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(NSPanelLovelaceMessageFromNextionTrigger),
+                        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                            NSPanelLovelaceMessageFromNextionTrigger
+                        ),
                     }
                 )
             ),
             cv.Optional(CONF_MESSAGE_TO_NEXTION): automation.validate_automation(
                 cv.Schema(
                     {
-                        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(NSPanelLovelaceMessageToNextionTrigger),
+                        cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                            NSPanelLovelaceMessageToNextionTrigger
+                        ),
                     }
                 )
             ),
@@ -77,11 +107,12 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_UPDATE_BAUD_RATE, default=921600): cv.positive_int,
         }
     )
-        .extend(uart.UART_DEVICE_SCHEMA)
-        .extend(cv.COMPONENT_SCHEMA),
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
     cv.only_with_arduino,
-    validate_config
-    )
+    validate_config,
+)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
@@ -95,8 +126,11 @@ async def to_code(config):
         cg.add(var.set_send_topic(config[CONF_MQTT_SEND_TOPIC]))
 
     cg.add(var.set_berry_driver_version(config[CONF_BERRY_DRIVER_VERSION]))
-    cg.add(var.set_missed_updates_workaround(config[CONF_USE_MISSED_UPDATES_WORKAROUND]))
+    cg.add(
+        var.set_missed_updates_workaround(config[CONF_USE_MISSED_UPDATES_WORKAROUND])
+    )
     cg.add(var.set_update_baud_rate(config[CONF_UPDATE_BAUD_RATE]))
+    cg.add(var.set_use_api(config[CONF_USE_API]))
 
     for conf in config.get(CONF_MESSAGE_FROM_NEXTION, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
@@ -104,7 +138,9 @@ async def to_code(config):
 
     for conf in config.get(CONF_MESSAGE_TO_NEXTION, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [(cg.std_string.operator("ref"), "x")], conf)
+        await automation.build_automation(
+            trigger, [(cg.std_string.operator("ref"), "x")], conf
+        )
 
     cg.add_library("WiFiClientSecure", None)
     cg.add_library("HTTPClient", None)

--- a/components/nspanel_lovelace/automation.h
+++ b/components/nspanel_lovelace/automation.h
@@ -9,10 +9,17 @@
 namespace esphome {
 namespace nspanel_lovelace {
 
-class NSPanelLovelaceMsgIncomingTrigger : public Trigger<std::string> {
+class NSPanelLovelaceMessageFromNextionTrigger : public Trigger<std::string> {
  public:
-  explicit NSPanelLovelaceMsgIncomingTrigger(NSPanelLovelace *parent) {
-    parent->add_incoming_msg_callback([this](const std::string &value) { this->trigger(value); });
+  explicit NSPanelLovelaceMessageFromNextionTrigger(NSPanelLovelace *parent) {
+    parent->add_message_from_nextion_callback([this](const std::string &value) { this->trigger(value); });
+  }
+};
+
+class NSPanelLovelaceMessageToNextionTrigger : public Trigger<std::string&> {
+ public:
+  explicit NSPanelLovelaceMessageToNextionTrigger(NSPanelLovelace *parent) {
+    parent->add_message_to_nextion_callback([this](std::string &value) { this->trigger(value); });
   }
 };
 

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -96,6 +96,7 @@ void NSPanelLovelace::app_flash_nextion(const std::string &payload) {
   App.scheduler.set_timeout(
       this, "nspanel_lovelace_flashnextion_upload", 100, [this, payload]() {
         ESP_LOGD(TAG, "Starting FlashNextion with URL '%s'", payload.c_str());
+        //!! need to add -- id(ble_tracker).stop_scan();
         this->upload_tft(payload);
       });
 }
@@ -157,12 +158,12 @@ bool NSPanelLovelace::process_data_() {
   const uint8_t *message_data = data + 4;
   std::string message(message_data, message_data + length);
 
-  this->process_command_(message);
+  this->process_command_from_nextion(message);
   this->buffer_.clear();
   return true;
 }
 
-void NSPanelLovelace::process_command_(const std::string &message) {
+void NSPanelLovelace::process_command_from_nextion(const std::string &message) {
   #ifdef USE_MQTT
   this->mqtt_->publish_json(this->recv_topic_, [message](ArduinoJson::JsonObject root){
     root["CustomRecv"] = message;

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -14,6 +14,10 @@ namespace nspanel_lovelace {
 
 static const char *const TAG = "nspanel_lovelace";
 
+#ifdef USE_API
+static const char *const HA_API_EVENT = "esphome.nspanel.data";
+#endif
+
 void NSPanelLovelace::setup() {
 
   #ifdef USE_MQTT
@@ -78,7 +82,7 @@ int NSPanelLovelace::app_get_driver_version() {
 
   #ifdef USE_API
   std::string message = std::to_string(this->berry_driver_version_);
-  this->fire_homeassistant_event("esphome.nspanel_data", {{"nlui_driver_version", message}});
+  this->fire_homeassistant_event(HA_API_EVENT, {{"nlui_driver_version", message}});
   #endif
 
   return this->berry_driver_version_;
@@ -166,7 +170,7 @@ void NSPanelLovelace::process_command_(const std::string &message) {
   #endif
 
   #ifdef USE_API
-  this->fire_homeassistant_event("esphome.nspanel_data", {{"CustomRecv", message}});
+  this->fire_homeassistant_event(HA_API_EVENT, {{"CustomRecv", message}});
   #endif
 
   // call message trigger

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -53,8 +53,8 @@ int NSPanelLovelace::app_get_driver_version() {
   #endif
 
   #ifdef USE_API
-  std::string str_berry_driver_version = std::to_string(this->berry_driver_version_);
-  this->fire_homeassistant_event("esphome.nspanel_nlui_driver_version", {{"payload", str_berry_driver_version}});
+  std::string message = std::to_string(this->berry_driver_version_);
+  this->fire_homeassistant_event("esphome.nspanel_data", {{"nlui_driver_version", message}});
   #endif
 
   return this->berry_driver_version_;
@@ -142,7 +142,7 @@ void NSPanelLovelace::process_command_(const std::string &message) {
   #endif
 
   #ifdef USE_API
-  this->fire_homeassistant_event("esphome.nspanel_customrecv", {{"payload", message}});
+  this->fire_homeassistant_event("esphome.nspanel_data", {{"CustomRecv", message}});
   #endif
 
   // call message trigger

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -60,6 +60,7 @@ void NSPanelLovelace::setup() {
     } });
     automation->add_actions({lambdaaction});
   #endif
+  }
 }
 
 void NSPanelLovelace::app_custom_send(const std::string &payload) {

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -5,6 +5,10 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/util.h"
 
+#ifdef USE_API
+#include "esphome/core/base_automation.h"
+#endif
+
 namespace esphome {
 namespace nspanel_lovelace {
 
@@ -28,6 +32,26 @@ void NSPanelLovelace::setup() {
                              this->app_flash_nextion(payload);
                            });
   }
+  #endif
+
+  #ifdef USE_API
+    auto api_userservicetrigger = new api::UserServiceTrigger<int32_t, std::string>("nspanelui_api_call", {"command", "data"});
+    api::global_api_server->register_user_service(api_userservicetrigger);
+    auto automation = new Automation<int32_t, std::string>(api_userservicetrigger);
+    auto lambdaaction = new LambdaAction<int32_t, std::string>([=](int32_t command, std::string data) -> void {
+        switch (command) {
+          case 1: // GetDriverVersion
+            this->app_get_driver_version();
+            break;
+          case 2: // CustomSend
+            this->app_custom_send(data);
+            break;
+          case 255: // FlashNextionTft
+            this->app_flash_nextion(data);
+            break;
+        }
+    });
+    automation->add_actions({lambdaaction});
   #endif
 }
 

--- a/components/nspanel_lovelace/nspanel_lovelace.h
+++ b/components/nspanel_lovelace/nspanel_lovelace.h
@@ -54,6 +54,8 @@ class NSPanelLovelace : public Component, public uart::UARTDevice,
 
   void send_nextion_command(const std::string &command);
 
+  void process_command_from_nextion(const std::string &message);
+
   /**
    * Softreset the Nextion
    */
@@ -85,7 +87,6 @@ class NSPanelLovelace : public Component, public uart::UARTDevice,
   uint16_t recv_ret_string_(std::string &response, uint32_t timeout, bool recv_flag);
 
   bool process_data_();
-  void process_command_(const std::string &message);
 
   #ifdef USE_MQTT
   mqtt::MQTTClientComponent *mqtt_;

--- a/components/nspanel_lovelace/nspanel_lovelace.h
+++ b/components/nspanel_lovelace/nspanel_lovelace.h
@@ -42,6 +42,7 @@ class NSPanelLovelace : public Component, public uart::UARTDevice,
   void set_berry_driver_version(unsigned int value) { berry_driver_version_ = value; }
   void set_missed_updates_workaround(bool value) { use_missed_updates_workaround_ = value; }
   void set_update_baud_rate(unsigned int value) { update_baud_rate_ = value; }
+  void set_use_api(bool value) { use_api_ = value; }
 
   float get_setup_priority() const override { return setup_priority::DATA; }
 
@@ -96,6 +97,7 @@ class NSPanelLovelace : public Component, public uart::UARTDevice,
   unsigned int berry_driver_version_;
   bool use_missed_updates_workaround_ = true;
   unsigned int update_baud_rate_;
+  bool use_api_ = false;
 
   CallbackManager<void(std::string)> message_from_nextion_callback_;
   CallbackManager<void(std::string&)> message_to_nextion_callback_;
@@ -119,6 +121,7 @@ class NSPanelLovelace : public Component, public uart::UARTDevice,
    */
   int content_length_ = 0;
   int tft_size_ = 0;
+  int last_upload_percentage_ = 0;
   int upload_by_chunks_(HTTPClient *http, const std::string &url, int range_start);
 
   void upload_end_();

--- a/components/nspanel_lovelace/nspanel_lovelace.h
+++ b/components/nspanel_lovelace/nspanel_lovelace.h
@@ -2,7 +2,6 @@
 
 #include <utility>
 
-#include "esphome/components/mqtt/mqtt_client.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/uart/uart_component_esp32_arduino.h"
 #include "esphome/core/automation.h"
@@ -11,6 +10,14 @@
 
 #include <HTTPClient.h>
 
+#ifdef USE_MQTT
+#include "esphome/components/mqtt/mqtt_client.h"
+#endif
+
+#ifdef USE_API
+#include "esphome/components/api/custom_api_device.h"
+#endif
+
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
 #endif
@@ -18,14 +25,20 @@
 namespace esphome {
 namespace nspanel_lovelace {
 
-class NSPanelLovelace : public Component, public uart::UARTDevice {
+class NSPanelLovelace : public Component, public uart::UARTDevice, 
+  #ifdef USE_API
+    public esphome::api::CustomAPIDevice
+  #endif 
+{
  public:
   void setup() override;
   void loop() override;
 
+  #ifdef USE_MQTT
   void set_mqtt(mqtt::MQTTClientComponent *parent) { mqtt_ = parent; }
   void set_recv_topic(const std::string &topic) { recv_topic_ = topic; }
   void set_send_topic(const std::string &topic) { send_topic_ = topic; }
+  #endif
   void set_berry_driver_version(unsigned int value) { berry_driver_version_ = value; }
   void set_missed_updates_workaround(bool value) { use_missed_updates_workaround_ = value; }
   void set_update_baud_rate(unsigned int value) { update_baud_rate_ = value; }
@@ -36,7 +49,8 @@ class NSPanelLovelace : public Component, public uart::UARTDevice {
 
   void send_custom_command(const std::string &command);
 
-  void add_incoming_msg_callback(std::function<void(std::string)> callback);
+  void add_message_from_nextion_callback(std::function<void(std::string)> callback) { this->message_from_nextion_callback_.add(std::move(callback)); }
+  void add_message_to_nextion_callback(std::function<void(std::string&)> callback) { this->message_to_nextion_callback_.add(std::move(callback)); }
 
   void send_nextion_command(const std::string &command);
 
@@ -59,6 +73,10 @@ class NSPanelLovelace : public Component, public uart::UARTDevice {
    */
   void upload_tft(const std::string &url);
 
+  void app_custom_send(const std::string &payload);
+  int app_get_driver_version();
+  void app_flash_nextion(const std::string &payload);
+
  protected:
   void set_baud_rate_(int baud_rate);
 
@@ -69,14 +87,17 @@ class NSPanelLovelace : public Component, public uart::UARTDevice {
   bool process_data_();
   void process_command_(const std::string &message);
 
+  #ifdef USE_MQTT
   mqtt::MQTTClientComponent *mqtt_;
   std::string recv_topic_;
   std::string send_topic_;
+  #endif
   unsigned int berry_driver_version_;
   bool use_missed_updates_workaround_ = true;
   unsigned int update_baud_rate_;
 
-  CallbackManager<void(std::string)> incoming_msg_callback_;
+  CallbackManager<void(std::string)> message_from_nextion_callback_;
+  CallbackManager<void(std::string&)> message_to_nextion_callback_;
 
   std::vector<uint8_t> buffer_;
 


### PR DESCRIPTION
Based on the already merged PR to joBr99/nspanel-lovelace-ui#1007 I would love to see the use of HA API.
It results in smoother and faster communication through HA events and HA services.

esphome needs small config change, optional new/renamed triggers

```yaml
nspanel_lovelace:
  use_api: True
  on_message_from_nextion:
    - lambda: |-
        ESP_LOGD("main", "message from nextion: %s", x.c_str());
  on_message_to_nextion:
    - lambda: |-
        ESP_LOGD("main", "message to nextion: %s", x.c_str());
```

nspanel.cpp automatically adds necessary HA service that the appdaemon backend can call (customrecv, updatetft, gerversion)

======

Afterwards HA ESP device needs explicit permission to use service calls.
![image](https://github.com/sairon/esphome-nspanel-lovelace-ui/assets/4489389/d9b75ab5-d4ee-4604-a79f-f5f23f746b28)
