### PR TITLE
fix: fix Arduino build with ESPHome 2025.7+

### DIFF
--- a/components/nspanel_lovelace/__init__.py
+++ b/components/nspanel_lovelace/__init__.py
@@ -82,7 +82,7 @@ async def to_code(config):
         await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     if CORE.is_esp32 and CORE.using_arduino:
-        cg.add_library("WiFiClientSecure", None)
+        cg.add_library("NetworkClientSecure", None)
         cg.add_library("HTTPClient", None)
 
     cg.add_define("USE_NSPANEL_LOVELACE")


### PR DESCRIPTION
I believe this is now the library that needs to be referenced WifiClientSecure is part of NetworkClientSecure it seems