### PR TITLE
Make temperature graph smooth

### DIFF
--- a/examples/advanced-config.yml
+++ b/examples/advanced-config.yml
@@ -171,6 +171,10 @@ sensor:
       reference_temperature: 25°C
       reference_resistance: 10kOhm
     name: $friendly_devicename Temperature
+    filters:
+      - sliding_window_moving_average:
+          window_size: 15
+          send_every: 15
 
 output:
   # Buzzer for playing tones

--- a/examples/advanced-config.yml
+++ b/examples/advanced-config.yml
@@ -25,6 +25,7 @@ logger:
     ntc: WARN
 
 ota:
+  - platform: esphome
 
 # API. Add api_pwd to your secrets.yaml.
 api:

--- a/examples/advanced-config.yml
+++ b/examples/advanced-config.yml
@@ -25,7 +25,6 @@ logger:
     ntc: WARN
 
 ota:
-  safe_mode: true
 
 # API. Add api_pwd to your secrets.yaml.
 api:

--- a/examples/basic-config.yml
+++ b/examples/basic-config.yml
@@ -62,6 +62,10 @@ sensor:
      reference_temperature: 25°C
      reference_resistance: 10kOhm
    name: $device_name Temperature
+   filters:
+     - sliding_window_moving_average:
+         window_size: 15
+         send_every: 15
 
  - platform: resistance
    id: resistance_sensor

--- a/examples/basic-config.yml
+++ b/examples/basic-config.yml
@@ -26,6 +26,7 @@ nspanel_lovelace:
   id: nspanel
 
 ota:
+  - platform: esphome
 
 logger:
 


### PR DESCRIPTION
- Smooth graphs like this
![a_002](https://github.com/user-attachments/assets/0108da29-b4bb-4405-a90f-a5473bc3bf56)  
- Remove `safe_mode`, this parameter is now enabled by default when ota is enabled.  
- And support esphome new `ota` mandatory parameters.