### PR TITLE
Fix tft upload

### DIFF
--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -106,6 +106,7 @@ void NSPanelLovelace::process_command_(const std::string &message) {
   this->mqtt_->publish_json(this->recv_topic_, [message](ArduinoJson::JsonObject root){
     root["CustomRecv"] = message;
   });
+  ESP_LOGD(TAG, "Sending custom command: %s", command.c_str());
   this->incoming_msg_callback_.call(message);
 }
 

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -106,7 +106,7 @@ void NSPanelLovelace::process_command_(const std::string &message) {
   this->mqtt_->publish_json(this->recv_topic_, [message](ArduinoJson::JsonObject root){
     root["CustomRecv"] = message;
   });
-  ESP_LOGD(TAG, "Received custom command: %s", command.c_str());
+  ESP_LOGD(TAG, "Received custom command: %s", message.c_str());
   this->incoming_msg_callback_.call(message);
 }
 

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -106,7 +106,7 @@ void NSPanelLovelace::process_command_(const std::string &message) {
   this->mqtt_->publish_json(this->recv_topic_, [message](ArduinoJson::JsonObject root){
     root["CustomRecv"] = message;
   });
-  ESP_LOGD(TAG, "Sending custom command: %s", command.c_str());
+  ESP_LOGD(TAG, "Received custom command: %s", command.c_str());
   this->incoming_msg_callback_.call(message);
 }
 

--- a/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
@@ -172,13 +172,12 @@ int NSPanelLovelace::upload_by_chunks_(const std::string &url, int range_start) 
   } else {
     ESP_LOGV(TAG, "Memory for buffer allocated successfully");
 
-    int low_heap_amt = esp_get_free_heap_size() - 32768;
 
     while (true) {
       App.feed_wdt();
       ESP_LOGVV(TAG, "Available heap: %u", esp_get_free_heap_size());
 
-      if (esp_get_free_heap_size() < low_heap_amt){
+      if (esp_get_free_heap_size() < 4096){
         ESP_LOGD(TAG, "Low heap");
         vTaskDelay(pdMS_TO_TICKS(1000));
         continue;

--- a/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
@@ -1,3 +1,4 @@
+#include <regex>
 #include "nspanel_lovelace.h"
 
 #include "esphome/core/application.h"
@@ -171,9 +172,19 @@ int NSPanelLovelace::upload_by_chunks_(const std::string &url, int range_start) 
   } else {
     ESP_LOGV(TAG, "Memory for buffer allocated successfully");
 
+    int low_heap_amt = esp_get_free_heap_size() - 32768;
+
     while (true) {
       App.feed_wdt();
       ESP_LOGVV(TAG, "Available heap: %u", esp_get_free_heap_size());
+
+      if (esp_get_free_heap_size() < low_heap_amt){
+        ESP_LOGD(TAG, "Low heap");
+        vTaskDelay(pdMS_TO_TICKS(1000));
+        continue;
+      }
+
+      vTaskDelay(pdMS_TO_TICKS(2));
       int read_len = esp_http_client_read(client, reinterpret_cast<char *>(buffer), 4096);
       ESP_LOGVV(TAG, "Read %d bytes from HTTP client, writing to UART", read_len);
       if (read_len > 0) {
@@ -336,6 +347,9 @@ void NSPanelLovelace::upload_tft(const std::string &url) {
   }
 
   this->is_updating_ = true;
+  this->mqtt_->unsubscribe(this->send_topic_);
+  this->mqtt_->unsubscribe(std::regex_replace(this->send_topic_, std::regex("CustomSend"), "GetDriverVersion"));
+  this->mqtt_->unsubscribe(std::regex_replace(this->send_topic_, std::regex("CustomSend"), "FlashNextion"));
 
 #ifdef USE_ARDUINO
   HTTPClient http;

--- a/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
@@ -191,7 +191,7 @@ int NSPanelLovelace::upload_by_chunks_(const std::string &url, int range_start) 
         ESP_LOGVV(TAG, "Write to UART successful");
         this->recv_ret_string_(recv_string, 5000, true);
         this->content_length_ -= read_len;
-        ESP_LOGD(TAG, "Uploaded %0.2f %%, remaining %d bytes, free heap $u bytes",
+        ESP_LOGD(TAG, "Uploaded %0.2f %%, remaining %d bytes, free heap %u bytes",
                  100.0 * (this->tft_size_ - this->content_length_) / this->tft_size_, this->content_length_, esp_get_free_heap_size());
         if (recv_string[0] != 0x05) {  // 0x05 == "ok"
           ESP_LOGD(

--- a/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace_upload.cpp
@@ -191,8 +191,8 @@ int NSPanelLovelace::upload_by_chunks_(const std::string &url, int range_start) 
         ESP_LOGVV(TAG, "Write to UART successful");
         this->recv_ret_string_(recv_string, 5000, true);
         this->content_length_ -= read_len;
-        ESP_LOGD(TAG, "Uploaded %0.2f %%, remaining %d bytes",
-                 100.0 * (this->tft_size_ - this->content_length_) / this->tft_size_, this->content_length_);
+        ESP_LOGD(TAG, "Uploaded %0.2f %%, remaining %d bytes, free heap $u bytes",
+                 100.0 * (this->tft_size_ - this->content_length_) / this->tft_size_, this->content_length_, esp_get_free_heap_size());
         if (recv_string[0] != 0x05) {  // 0x05 == "ok"
           ESP_LOGD(
               TAG, "recv_string [%s]",


### PR DESCRIPTION
This PR fixes memory "leak" caused by received MQTT messages by unsubscribing from all MQTT topics when uploading tft.