### PR TITLE
fix safe_mode and ota configuration

### DIFF
--- a/examples/advanced-config.yml
+++ b/examples/advanced-config.yml
@@ -25,7 +25,11 @@ logger:
     ntc: WARN
 
 ota:
-  safe_mode: true
+  platform: esphome
+
+safe_mode:
+  num_attempts: 5
+  reboot_timeout: 5min
 
 # API. Add api_pwd to your secrets.yaml.
 api:


### PR DESCRIPTION
safe_mode (and its related configuration variables) has moved from 'ota' to its own component. 
See https://esphome.io/components/safe_mode