### PR TITLE
fix: fix Arduino build with ESPHome 2026.7.0+

### DIFF
--- a/components/nspanel_lovelace/__init__.py
+++ b/components/nspanel_lovelace/__init__.py
@@ -83,7 +83,14 @@ async def to_code(config):
         await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     if CORE.is_esp32 and CORE.using_arduino:
-        cg.add_library("Networking", None)
+        if getattr(CORE, "using_toolchain_esp_idf", False):
+            # ESP-IDF toolchain (ESPHome 2026.7.0+) enables built-in Arduino
+            # libraries by their folder/CMake name
+            cg.add_library("Network", None)
+        else:
+            # PlatformIO LDF resolves the same library by its
+            # library.properties name
+            cg.add_library("Networking", None)
         cg.add_library("NetworkClientSecure", None)
         cg.add_library("HTTPClient", None)
     elif CORE.is_esp32:


### PR DESCRIPTION
ESPHome 2026.7.0 builds ESP32 Arduino configs with the ESP-IDF toolchain, where built-in Arduino libraries must be referenced by their folder name (Network) instead of the library.properties name (Networking) used by the PlatformIO LDF, otherwise ESPHome attempts to resolve them in the PlatformIO registry and fails.