### PR TITLE
chore: fix examples for compatibility with current ESPHome

### DIFF
--- a/examples/advanced-config.yml
+++ b/examples/advanced-config.yml
@@ -9,6 +9,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  framework:
+    type: arduino
 
 wifi:
   networks:
@@ -25,7 +27,7 @@ logger:
     ntc: WARN
 
 ota:
-  safe_mode: true
+  - platform: esphome
 
 # API. Add api_pwd to your secrets.yaml.
 api:

--- a/examples/basic-config.yml
+++ b/examples/basic-config.yml
@@ -26,6 +26,7 @@ nspanel_lovelace:
   id: nspanel
 
 ota:
+  - platform: esphome
 
 logger:
 


### PR DESCRIPTION
OTA requires a platform since ESPHome 2024.6 (safe mode is split into its own component that is auto-loaded by OTA), and since 2026.1 the default ESP32 framework is ESP-IDF, so make the Arduino framework explicit in the advanced example.