### PR TITLE
ci: add example configs to build test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
         config:
           - tests/test-arduino.yaml
           - tests/test-esp-idf.yaml
+          - tests/test-example-basic.yaml
+          - tests/test-example-advanced.yaml
         esphome-version: [stable, beta, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -27,7 +29,7 @@ jobs:
           path: |
             ~/.platformio
             ~/.cache
-          key: esphome-${{ matrix.esphome-version }}-${{ matrix.config }}-${{ hashFiles('components/**', 'tests/**') }}
+          key: esphome-${{ matrix.esphome-version }}-${{ matrix.config }}-${{ hashFiles('components/**', 'tests/**', 'examples/**') }}
           restore-keys: |
             esphome-${{ matrix.esphome-version }}-${{ matrix.config }}-
       - uses: esphome/build-action@4ef4722a2935eac47b7e227fe0e1f8e0f8afcc42 # v7.3.0

--- a/tests/secrets.yaml
+++ b/tests/secrets.yaml
@@ -1,0 +1,6 @@
+# Dummy secrets for the example configs built in CI
+wifi_ssid: ci-ssid
+wifi_password: ci-password
+mqtt_ip: 192.168.1.1
+mqtt_username: ci-user
+mqtt_password: ci-password

--- a/tests/test-example-advanced.yaml
+++ b/tests/test-example-advanced.yaml
@@ -1,0 +1,11 @@
+packages:
+  example: !include ../examples/advanced-config.yml
+
+# The main config is merged after packages, so this source is processed last
+# and takes precedence over the example's git source, making the build use
+# the component from this checkout.
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [nspanel_lovelace]

--- a/tests/test-example-basic.yaml
+++ b/tests/test-example-basic.yaml
@@ -1,0 +1,11 @@
+packages:
+  example: !include ../examples/basic-config.yml
+
+# The main config is merged after packages, so this source is processed last
+# and takes precedence over the example's git source, making the build use
+# the component from this checkout.
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [nspanel_lovelace]


### PR DESCRIPTION
Examples are built via test configs that include them as packages and override the external component source with the local checkout, so PRs are tested against their own code. The main config is merged after packages and its source is processed last, taking precedence over the example's git source. Secrets are provided by a dummy secrets.yaml.